### PR TITLE
Shorten joseph.py

### DIFF
--- a/submissions/challenge1/joseph.py
+++ b/submissions/challenge1/joseph.py
@@ -5,4 +5,4 @@ Notes:
 Solution only works on certain environments and requires the 'bc' package to be installed
 """
 
-next(c for c in object.__subclasses__()if'ModuleLock'in str(c)).acquire.__globals__['sys'].modules['os'].execve("dc",("dc","-e",input()+"p"))
+next(c for c in object.__subclasses__()if'ModuleLock'in str(c)).acquire.__globals__['sys'].modules['os'].execvp("dc",("dc","-e",input()+"p"))

--- a/submissions/challenge1/joseph.py
+++ b/submissions/challenge1/joseph.py
@@ -5,4 +5,4 @@ Notes:
 Solution only works on certain environments and requires the 'bc' package to be installed
 """
 
-next(c for c in object.__subclasses__()if'ModuleLock'in str(c)).acquire.__globals__['sys'].modules['os'].execve("/bin/dc",("dc","-e",input()+"p"),{})
+next(c for c in object.__subclasses__()if'ModuleLock'in str(c)).acquire.__globals__['sys'].modules['os'].execve("dc",("dc","-e",input()+"p"))


### PR DESCRIPTION
By using `os.execvp` instead of `os.execve` I can actually just carry over the parent env, meaning I don't need that third argument. This also means that the `dc` binary is in the path which gets carried over, so I can just call `dc` instead of `/bin/dc`.